### PR TITLE
PostgreSQL patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,14 +89,6 @@ this will improve the new link 'fetch title' capability and potentially more
     $ make
     $ sudo reddit-start
 
-### Configure PostgreSQL
-
-Increase PostgreSQL `max_connections` to 150 for greater stability (87/100 in use at idle without Solr)
-
-    $ sudo nano /etc/postgresql/9.3/main/postgresql.conf
-    $ sudo service postgresql restart
-    $ sudo reddit-restart
-
 ### Install sample data
 
 This also creates a reddit admin user "saidit" with password "password".

--- a/install/setup_postgres.sh
+++ b/install/setup_postgres.sh
@@ -69,3 +69,6 @@ create or replace function domain(url text) returns text as \$\$
     select substring(\$1 from E'(?i)(?:.+?://)?(?:www[\\d]*\\.)?([^#/]*)/?')
 \$\$ language sql immutable;
 FUNCTIONSQL
+
+sudo sed -i "s/^max_connections = .*$/max_connections = 150/" /etc/postgresql/9.3/main/postgresql.conf
+sudo service postgresql restart


### PR DESCRIPTION
This commit patches the installer to automatically apply a postgresql patch to increase `max_connections` that previously had to be applied manually. Without this patch saidit would fail on boot.

The patch has been inserted into a script that sets up postgres. It will automatically apply the patch and reboot the Postgres server since the saidit app has not started yet.