### PR TITLE
Add subreddit navigation menu buttons to comment pages with CSS

### DIFF
--- a/r2/r2/lib/pages/pages.py
+++ b/r2/r2/lib/pages/pages.py
@@ -2025,6 +2025,23 @@ class LinkInfoPage(Reddit):
         if self.show_promote_button:
             buttons.append(NavButton(menu.promote, 'promoted', sr_path=False))
 
+        buttons.append(NamedButton('hot', css_class='commentpage-toggle', dest='', aliases=['/hot'], sr_path=True))
+        buttons.append(NamedButton('new', css_class='commentpage-toggle', sr_path=True))
+        buttons.append(NamedButton(g.voting_upvote_path, css_class='commentpage-toggle', sr_path=True))
+        buttons.append(NamedButton(g.voting_controversial_path, css_class='commentpage-toggle', sr_path=True))
+        buttons.append(NamedButton('top', css_class='commentpage-toggle', sr_path=True))
+        
+        if feature.is_enabled('sr_comments_tab'):
+            buttons.append(NamedButton('comments', css_class='commentpage-toggle', sr_path=True))
+
+        mod = False
+        if c.user_is_loggedin:
+            mod = bool(c.user_is_admin
+                       or c.site.is_moderator_with_perms(c.user, 'wiki'))
+        if c.site._should_wiki and (c.site.wikimode != 'disabled' or mod):
+            if not g.disable_wiki:
+                buttons.append(NavButton('wiki', 'wiki', css_class='commentpage-toggle', sr_path=True))
+            
         toolbar = [NavMenu(buttons, base_path = "", type="tabmenu")]
 
         if not isinstance(c.site, DefaultSR):

--- a/r2/r2/public/static/css/theme-custom.less
+++ b/r2/r2/public/static/css/theme-custom.less
@@ -184,3 +184,8 @@
         max-width: 100%;
     }
 }
+
+/* Hide Nav Menu On Comment Pages */
+.tabmenu .commentpage-toggle {
+    display: none;
+}


### PR DESCRIPTION
This will add the navigation buttons to comment pages. 

'hot', 'new', insightful', 'fun', 'top', 'comments', 'wiki')

They are disabled by default through CSS and need to be enabled per subreddit in the subreddit CSS.