### PR TITLE
Fix Twitch embeds

### DIFF
--- a/r2/r2/lib/media.py
+++ b/r2/r2/lib/media.py
@@ -1838,6 +1838,8 @@ class _TwitchScraper(_ThumbnailOnlyScraper):
             self.url = self.CLIP_URL + 'clip=' + clip_channel_match.group(2) + '&muted=false'
         else:
             return None, None, None, None
+        
+        self.url += '&parent=' + g.domain
             
         uid = _filename_from_content(image_data)
         image = str_to_image(image_data)


### PR DESCRIPTION
Twitch updated their embed url to require the sites domain in the 'parent' parameter in order to work.
https://dev.twitch.tv/docs/embed/video-and-clips
https://dev.twitch.tv/docs/change-log