### PR TITLE
Fix approve/remove buttons

### DIFF
--- a/r2/r2/lib/pages/things.py
+++ b/r2/r2/lib/pages/things.py
@@ -57,8 +57,7 @@ class PrintableButtons(Styled):
                  **kw):
         show_ignore = thing.show_reports
         approval_checkmark = getattr(thing, "approval_checkmark", None)
-        show_approve = (thing.show_spam or show_ignore or
-                        (is_link and approval_checkmark is None)) and not thing._deleted
+        show_approve = (thing.show_spam or show_ignore) and not thing._deleted
 
         Styled.__init__(self, style = style,
                         thing = thing,

--- a/r2/r2/templates/printablebuttons.html
+++ b/r2/r2/templates/printablebuttons.html
@@ -235,11 +235,8 @@
   <span class="big-mod-buttons">
     %if not thing._deleted:
       <span role="radiogroup">
-        %if not getattr(thing, "moderator_banned", None) or getattr(thing, "autobanned", False):
-          ${pretty_button(_("spam"), "big_mod_action", -2, "negative", event_action="spam")}
-          ${pretty_button(_("remove"), "big_mod_action", -1, "neutral", event_action="remove")}
-        %endif
-
+        ${pretty_button(_("spam"), "big_mod_action", -2, "negative", event_action="spam")}
+        ${pretty_button(_("remove"), "big_mod_action", -1, "neutral", event_action="remove")}
         %if getattr(thing, "approval_checkmark", None):
           ${pretty_button(_("reapprove"), "big_mod_action",  1, "positive", event_action="approve")}
         %else:

--- a/r2/r2/templates/printablebuttons.m
+++ b/r2/r2/templates/printablebuttons.m
@@ -235,11 +235,8 @@
   <span class="big-mod-buttons">
     %if not thing._deleted:
       <span role="radiogroup">
-        %if not getattr(thing, "moderator_banned", None) or getattr(thing, "autobanned", False):
-          ${pretty_button(_("spam"), "big_mod_action", -2, "negative", event_action="spam")}
-          ${pretty_button(_("remove"), "big_mod_action", -1, "neutral", event_action="remove")}
-        %endif
-
+        ${pretty_button(_("spam"), "big_mod_action", -2, "negative", event_action="spam")}
+        ${pretty_button(_("remove"), "big_mod_action", -1, "neutral", event_action="remove")}
         %if getattr(thing, "approval_checkmark", None):
           ${pretty_button(_("reapprove"), "big_mod_action",  1, "positive", event_action="approve")}
         %else:


### PR DESCRIPTION
I removed the approve button from posts that aren't removed, because it's unnecessary and can lead to mods and admins accidentally approving them (could still happen with the big green one when it's removed or reported, but it should be less common now). I also added the the "spam" and "remove" buttons to removed items, in case mods want to change the removal type (spam vs. not spam) without having to approve them first.