### PR TITLE
Change wrong password message to wrong username OR password

### DIFF
--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -1404,6 +1404,7 @@ class ApiController(RedditController):
         if not (form.has_errors('ratelimit', errors.RATELIMIT) or
                 form.has_errors("user", errors.NOT_USER) or
                 form.has_errors("passwd", errors.WRONG_PASSWORD) or
+                form.has_errors("passwd", errors.INCORRECT_USERNAME_OR_PASSWORD) or
                 form.has_errors("deactivate_message", errors.TOO_LONG) or
                 form.has_errors("confirm", errors.CONFIRM)):
             redirect_url = "/?deactivated=true"

--- a/r2/r2/controllers/login.py
+++ b/r2/r2/controllers/login.py
@@ -86,6 +86,9 @@ def handle_login(
     elif responder.has_errors("passwd", errors.WRONG_PASSWORD):
         _event(error='WRONG_PASSWORD')
 
+    elif responder.has_errors("passwd", errors.INCORRECT_USERNAME_OR_PASSWORD):
+        _event(error='INCORRECT_USERNAME_OR_PASSWORD')
+
     else:
         controller._login(responder, user, rem)
         _event(error=None)

--- a/r2/r2/lib/errors.py
+++ b/r2/r2/lib/errors.py
@@ -55,6 +55,7 @@ error_list = dict((
         ('SHORT_PASSWORD', _('the password must be at least %(chars)d characters')),
         ('BAD_PASSWORD', _('that password is unacceptable')),
         ('WRONG_PASSWORD', _('wrong password')),
+        ('INCORRECT_USERNAME_OR_PASSWORD', _('incorrect username or password')),
         ('BAD_PASSWORD_MATCH', _('passwords do not match')),
         ('NO_NAME', _('please enter a name')),
         ('NO_EMAIL', _('please enter an email address')),

--- a/r2/r2/lib/validator/validator.py
+++ b/r2/r2/lib/validator/validator.py
@@ -1640,7 +1640,7 @@ class LoginRatelimit(object):
 
 class VThrottledLogin(VRequired):
     def __init__(self, params):
-        VRequired.__init__(self, params, error=errors.WRONG_PASSWORD)
+        VRequired.__init__(self, params, error=errors.INCORRECT_USERNAME_OR_PASSWORD)
         self.vlength = VLength("user", max_length=100)
         self.seconds = None
 

--- a/r2/r2/templates/login.html
+++ b/r2/r2/templates/login.html
@@ -84,7 +84,7 @@
                %endif
                >
       </%call>
-      <%call expr="form_group('passwd', 'BAD_PASSWORD', 'WRONG_PASSWORD', show_errors=True)">
+      <%call expr="form_group('passwd', 'BAD_PASSWORD', 'WRONG_PASSWORD', 'INCORRECT_USERNAME_OR_PASSWORD', show_errors=True)">
         <label for="passwd_${op}" class="screenreader-only">${_('password')}:</label>
         <input id="passwd_${op}" class="c-form-control" name="passwd" type="password"
                tabindex="${tabindex}" placeholder="${_('password')}"
@@ -196,6 +196,7 @@
               ${error_field("BAD_PASSWORD", "passwd", kind="span")}
             %else:
               ${error_field("WRONG_PASSWORD", "passwd", kind="span")}
+              ${error_field("INCORRECT_USERNAME_OR_PASSWORD", "passwd", kind="span")}
             %endif
           </li>
         %if register:

--- a/r2/r2/templates/login.m
+++ b/r2/r2/templates/login.m
@@ -85,7 +85,7 @@
                %endif
                >
       </%call>
-      <%call expr="form_group('passwd', 'BAD_PASSWORD', 'WRONG_PASSWORD', show_errors=True)">
+      <%call expr="form_group('passwd', 'BAD_PASSWORD', 'WRONG_PASSWORD', 'INCORRECT_USERNAME_OR_PASSWORD', show_errors=True)">
         <label for="passwd_${op}" class="screenreader-only">${_('password')}:</label>
         <input id="passwd_${op}" class="c-form-control" name="passwd" type="password"
                tabindex="${tabindex}" placeholder="${_('password')}"
@@ -197,6 +197,7 @@
               ${error_field("BAD_PASSWORD", "passwd", kind="span")}
             %else:
               ${error_field("WRONG_PASSWORD", "passwd", kind="span")}
+              ${error_field("INCORRECT_USERNAME_OR_PASSWORD", "passwd", kind="span")}
             %endif
           </li>
         %if register:

--- a/r2/r2/templates/prefdeactivate.html
+++ b/r2/r2/templates/prefdeactivate.html
@@ -71,6 +71,7 @@
     <input name="user" id="deactivate-user" type="text" />
     <label for="deactivate-password">${_("password")}</label>
     ${error_field("WRONG_PASSWORD", "passwd")}
+    ${error_field("INCORRECT_USERNAME_OR_PASSWORD", "passwd")}
     <input name="passwd" id="deactivate-password" type="password" />
   </%utils:round_field>
 </div>  

--- a/r2/r2/templates/prefdeactivate.m
+++ b/r2/r2/templates/prefdeactivate.m
@@ -71,6 +71,7 @@
     <input name="user" id="deactivate-user" type="text" />
     <label for="deactivate-password">${_("password")}</label>
     ${error_field("WRONG_PASSWORD", "passwd")}
+    ${error_field("INCORRECT_USERNAME_OR_PASSWORD", "passwd")}
     <input name="passwd" id="deactivate-password" type="password" />
   </%utils:round_field>
 </div>  

--- a/r2/r2/templates/register.m
+++ b/r2/r2/templates/register.m
@@ -84,7 +84,7 @@
                %endif
                >
       </%call>
-      <%call expr="form_group('passwd', 'BAD_PASSWORD', 'WRONG_PASSWORD', show_errors=True)">
+      <%call expr="form_group('passwd', 'BAD_PASSWORD', 'WRONG_PASSWORD', 'INCORRECT_USERNAME_OR_PASSWORD', show_errors=True)">
         <label for="passwd_${op}" class="screenreader-only">${_('password')}:</label>
         <input id="passwd_${op}" class="c-form-control" name="passwd" type="password"
                tabindex="${tabindex}" placeholder="${_('password')}"
@@ -194,6 +194,7 @@
               ${error_field("BAD_PASSWORD", "passwd", kind="span")}
             %else:
               ${error_field("WRONG_PASSWORD", "passwd", kind="span")}
+              ${error_field("INCORRECT_USERNAME_OR_PASSWORD", "passwd", kind="span")}
             %endif
           </li>
         %if register:


### PR DESCRIPTION
Saidit currently gives "wrong password" even if the username doesn't exist. It should probably say username OR password, because either one could be wrong.